### PR TITLE
Update test-and-release.yml - add node 20 tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [18.x] #, 20.x
+                node-version: [18.x, 20.x]
                 os: [ubuntu-latest, windows-latest, macos-latest] #, macos-latest
 
         steps:


### PR DESCRIPTION
This PR (re) adds node 20 tests.

Please note that you still mus update 

- adapter-core to 3.1.4 (PR #20)
- @iobroker/testing to 4.1.3 

to make tests pass.